### PR TITLE
Move `restify` to dependencies for Heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   "private": true,
   "dependencies": {
     "initai-dev-server": "^0.4.8",
-    "initai-node": "~0.0.7"
+    "initai-node": "~0.0.7",
+    "restify": "^4.3.0"
   },
   "devDependencies": {
-    "nodemon": "^1.11.0",
-    "restify": "^4.3.0"
+    "nodemon": "^1.11.0"
   }
 }


### PR DESCRIPTION
Heroku will not install `devDependencies`. `restify` is needed in prod too.